### PR TITLE
Add interactive XML selection and batch launcher

### DIFF
--- a/1717 N FLAG/DB/ParseXml.py
+++ b/1717 N FLAG/DB/ParseXml.py
@@ -1,16 +1,13 @@
-import xml.etree.ElementTree as ET
+import argparse
 import csv
+import sys
+import xml.etree.ElementTree as ET
 from datetime import datetime
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
 
-tree = ET.parse(r"C:\Users\Diego\daabcontech.com\PROJECTS - Documents\250909 - 1717 N Flagler\02_WIP\02.08 ISSUE REPORTS\XML\1717 N Flagler - Coordination Model_2025 - Abner - DANIEL.xml")
-root = tree.getroot()
 
-rows = []
-debug_lines = []
-seen = set()  # Track unique (GUID, CommentID) pairs
-view_counter = 0  # Global counter for vp####.jpg
-
-def parse_createddate(created):
+def parse_createddate(created, log):
     """Convert <createddate><date .../> into yyyy/mm/dd"""
     try:
         date_node = created.find("date") if created is not None else None
@@ -28,32 +25,33 @@ def parse_createddate(created):
         return dt.strftime("%Y/%m/%d")
 
     except Exception as e:
-        debug_lines.append(f"❌ Failed to parse createddate: {e}, raw={ET.tostring(created, encoding='unicode') if created is not None else 'None'}")
+        log(
+            f"❌ Failed to parse createddate: {e}, raw={ET.tostring(created, encoding='unicode') if created is not None else 'None'}"
+        )
         return None
 
-def add_row(row):
+def add_row(row, rows, seen, log):
     key = (row[4], row[5])  # GUID + CommentID
     if key not in seen:
         rows.append(row)
         seen.add(key)
     else:
-        debug_lines.append(f"⚠️ Duplicate skipped: GUID={row[4]}, CommentID={row[5]}")
+        log(f"⚠️ Duplicate skipped: GUID={row[4]}, CommentID={row[5]}")
 
-def recurse(folder, path):
-    global view_counter
 
+def recurse(folder, path, rows, seen, view_counter, log):
     folder_name = folder.attrib.get("name", "")
     new_path = path + [folder_name]
 
-    debug_lines.append(f"📂 Entering folder: {' > '.join(new_path)}")
+    log(f"📂 Entering folder: {' > '.join(new_path)}")
 
     for view in folder.findall("view"):
-        view_counter += 1
+        view_counter[0] += 1
         view_name = view.attrib.get("name", "")
         guid = view.attrib.get("guid", "")
-        image_file = f"vp{str(view_counter).zfill(4)}.jpg"
+        image_file = f"vp{str(view_counter[0]).zfill(4)}.jpg"
 
-        debug_lines.append(f"  👀 Found view: {view_name} (GUID={guid}) → {image_file}")
+        log(f"  👀 Found view: {view_name} (GUID={guid}) → {image_file}")
 
         comments = view.find("comments")
         if comments is not None:
@@ -63,9 +61,9 @@ def recurse(folder, path):
                 user = comment.findtext("user")
                 body = comment.findtext("body")
                 created = comment.find("createddate")
-                created_str = parse_createddate(created) if created is not None else None
+                created_str = parse_createddate(created, log) if created is not None else None
 
-                debug_lines.append(f"    💬 Comment ID={cid}, Status={status}, User={user}")
+                log(f"    💬 Comment ID={cid}, Status={status}, User={user}")
 
                 add_row([
                     new_path[0] if len(new_path) > 0 else None,
@@ -79,9 +77,9 @@ def recurse(folder, path):
                     body,
                     created_str,
                     image_file
-                ])
+                ], rows, seen, log)
         else:
-            debug_lines.append(f"    ⚠️ No comments found for {view_name}")
+            log(f"    ⚠️ No comments found for {view_name}")
             add_row([
                 new_path[0] if len(new_path) > 0 else None,
                 new_path[1] if len(new_path) > 1 else None,
@@ -90,28 +88,119 @@ def recurse(folder, path):
                 guid,
                 None, None, None, None, None,
                 image_file
-            ])
+            ], rows, seen, log)
 
     for child in folder.findall("viewfolder"):
-        recurse(child, new_path)
+        recurse(child, new_path, rows, seen, view_counter, log)
 
-# ✅ Start only at top-level categories
-for vf in root.findall("./viewpoints/viewfolder"):
-    recurse(vf, [])
 
-# Save main data to CSV
-with open("navisworks_views_comments.csv", "w", newline="", encoding="utf-8") as f:
-    writer = csv.writer(f)
-    writer.writerow([
-        "Category", "Level", "Subfolder",
-        "ViewName", "GUID",
-        "CommentID", "Status", "User", "Body", "CreatedDate",
-        "ImagePath"
-    ])
-    writer.writerows(rows)
+def choose_file_with_dialog() -> Optional[Path]:
+    try:
+        import tkinter as tk
+        from tkinter import filedialog
 
-# Save debug log
-with open("debug.txt", "w", encoding="utf-8") as f:
-    f.write("\n".join(debug_lines))
+        root = tk.Tk()
+        root.withdraw()
+        root.update()
+        selected = filedialog.askopenfilename(
+            title="Select XML file to parse",
+            filetypes=[("XML files", "*.xml"), ("All files", "*.*")],
+        )
+        root.destroy()
+        if selected:
+            return Path(selected)
+        return None
+    except Exception:
+        return None
 
-print("✅ Processing complete. Check navisworks_views_comments.csv and debug.txt")
+
+def ensure_xml_path(cli_path: Optional[str]) -> Path:
+    if cli_path:
+        path = Path(cli_path)
+        if path.is_file():
+            return path
+        raise FileNotFoundError(f"XML file not found: {cli_path}")
+
+    selected = choose_file_with_dialog()
+    if selected:
+        if selected.is_file():
+            return selected
+        raise FileNotFoundError(f"Selected file not found: {selected}")
+
+    print("Please enter the path to the XML file:")
+    user_input = input().strip().strip('"')
+    if not user_input:
+        raise ValueError("No XML file selected.")
+    path = Path(user_input)
+    if path.is_file():
+        return path
+    raise FileNotFoundError(f"XML file not found: {path}")
+
+
+def process_xml(xml_path: Path, stream_debug: bool = False) -> Tuple[List[List[Optional[str]]], List[str]]:
+    rows: List[List[Optional[str]]] = []
+    debug_lines: List[str] = []
+    seen: set = set()
+    view_counter = [0]
+
+    def log(message: str) -> None:
+        debug_lines.append(message)
+        if stream_debug:
+            print(message)
+
+    tree = ET.parse(str(xml_path))
+    root = tree.getroot()
+
+    for vf in root.findall("./viewpoints/viewfolder"):
+        recurse(vf, [], rows, seen, view_counter, log)
+
+    return rows, debug_lines
+
+
+def write_outputs(rows: Sequence[Sequence[Optional[str]]], debug_lines: Sequence[str]) -> None:
+    with open("navisworks_views_comments.csv", "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            "Category",
+            "Level",
+            "Subfolder",
+            "ViewName",
+            "GUID",
+            "CommentID",
+            "Status",
+            "User",
+            "Body",
+            "CreatedDate",
+            "ImagePath",
+        ])
+        writer.writerows(rows)
+
+    with open("debug.txt", "w", encoding="utf-8") as f:
+        f.write("\n".join(debug_lines))
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Parse Navisworks XML comments into CSV")
+    parser.add_argument("path", nargs="?", help="Path to the XML file to parse")
+    parser.add_argument(
+        "--stream-debug",
+        action="store_true",
+        help="Stream debug log messages to the console while processing",
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        xml_path = ensure_xml_path(args.path)
+        rows, debug_lines = process_xml(xml_path, stream_debug=args.stream_debug)
+        write_outputs(rows, debug_lines)
+    except Exception as exc:
+        print(f"❌ Error: {exc}")
+        return 1
+
+    print("✅ Processing complete. Check navisworks_views_comments.csv and debug.txt")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/1717 N FLAG/DB/RunParseXml.bat
+++ b/1717 N FLAG/DB/RunParseXml.bat
@@ -1,0 +1,32 @@
+@echo off
+setlocal enabledelayedexpansion
+
+rem Change to the directory of this script so relative paths work
+cd /d "%~dp0"
+
+rem Determine which Python command is available
+set "PYTHON_CMD="
+where python >nul 2>&1 && set "PYTHON_CMD=python"
+if not defined PYTHON_CMD (
+    where py >nul 2>&1 && set "PYTHON_CMD=py -3"
+)
+
+if not defined PYTHON_CMD (
+    echo Python interpreter not found. Please install Python or add it to PATH.
+    pause
+    exit /b 1
+)
+
+%PYTHON_CMD% "%~dp0ParseXml.py" --stream-debug
+set "ERR=%ERRORLEVEL%"
+
+if %ERR% neq 0 (
+    echo.
+    echo The parser encountered an error. Review the messages above and debug.txt for details.
+) else (
+    echo.
+    echo Parsing complete. Output saved to navisworks_views_comments.csv and debug.txt.
+)
+
+echo.
+pause


### PR DESCRIPTION
## Summary
- refactor ParseXml.py into a reusable CLI that can prompt for XML files via a file picker or manual path entry
- add optional streaming of debug log lines so verbose output can be viewed while parsing runs
- provide a RunParseXml.bat helper that launches the parser with streamed debug output on Windows

## Testing
- python "1717 N FLAG/DB/ParseXml.py" --help

------
https://chatgpt.com/codex/tasks/task_e_68d4b0632bb0832eac63587400316722