### PR TITLE
Align Navisworks export folder layout

### DIFF
--- a/DaabNavisExport/DaabNavisExport.csproj
+++ b/DaabNavisExport/DaabNavisExport.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>DaabNavisExport</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Autodesk.Navisworks.Api" />
+    <Reference Include="Autodesk.Navisworks.Api.DocumentParts" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+</Project>

--- a/DaabNavisExport/ExportPlugin.cs
+++ b/DaabNavisExport/ExportPlugin.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+using System.Xml;
+using Autodesk.Navisworks.Api;
+using Autodesk.Navisworks.Api.DocumentParts.Comments;
+using Autodesk.Navisworks.Api.Plugins;
+using DaabNavisExport.Parsing;
+using DaabNavisExport.Utilities;
+
+namespace DaabNavisExport
+{
+    [Plugin("DaabNavisExport", "DAAB", DisplayName = "Daab Navis Export", ToolTip = "Exports Navisworks viewpoints and comments to Daab Reports format", LoadForCanExecute = true)]
+    public class ExportPlugin : AddInPlugin
+    {
+        private const string DbFolderName = "DB";
+        private const string ImagesFolderName = "Images";
+
+        public override int Execute(params string[] parameters)
+        {
+            try
+            {
+                if (Application.ActiveDocument == null)
+                {
+                    MessageBox.Show("No active document open.", "Daab Navis Export", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return 0;
+                }
+
+                var document = Application.ActiveDocument;
+                var outputDirectory = ResolveOutputDirectory(parameters);
+                var exportContext = BuildExportContext(document, outputDirectory);
+
+                ExportViewpointsToXml(document, exportContext);
+
+                var parser = new NavisworksXmlParser();
+                var parseResult = parser.Process(exportContext.XmlPath);
+                parser.WriteOutputs(parseResult, exportContext.DbDirectory);
+
+                ExportViewpointImages(exportContext, parseResult.Rows);
+
+                MessageBox.Show(
+                    $"Export complete.\nProject folder: {exportContext.ProjectDirectory}\nXML: {exportContext.XmlPath}\nCSV: {Path.Combine(exportContext.DbDirectory, NavisworksXmlParser.CsvFileName)}",
+                    "Daab Navis Export",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Information);
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Export failed: {ex.Message}", "Daab Navis Export", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return -1;
+            }
+        }
+
+        private static ExportContext BuildExportContext(Document document, string outputDirectory)
+        {
+            Directory.CreateDirectory(outputDirectory);
+
+            var projectFolderName = ResolveProjectFolderName(document);
+            var projectDirectory = Path.Combine(outputDirectory, projectFolderName);
+            var dbDirectory = Path.Combine(projectDirectory, DbFolderName);
+            var imagesDirectory = Path.Combine(projectDirectory, ImagesFolderName);
+
+            Directory.CreateDirectory(projectDirectory);
+            Directory.CreateDirectory(dbDirectory);
+            Directory.CreateDirectory(imagesDirectory);
+
+            var xmlFile = Path.Combine(dbDirectory, "DB.xml");
+
+            return new ExportContext(document, outputDirectory, projectDirectory, dbDirectory, imagesDirectory, xmlFile);
+        }
+
+        private static string ResolveProjectFolderName(Document document)
+        {
+            var sourceName = document.FileName;
+            if (!string.IsNullOrWhiteSpace(sourceName))
+            {
+                var stem = Path.GetFileNameWithoutExtension(sourceName);
+                var sanitized = PathSanitizer.ToSafeFileName(stem);
+                if (!string.IsNullOrWhiteSpace(sanitized))
+                {
+                    return sanitized;
+                }
+            }
+
+            return $"Navisworks_{DateTime.Now:yyyyMMdd_HHmmss}";
+        }
+
+        private static string ResolveOutputDirectory(IReadOnlyList<string> parameters)
+        {
+            var explicitPath = parameters?.FirstOrDefault(p => !string.IsNullOrWhiteSpace(p));
+            if (!string.IsNullOrEmpty(explicitPath))
+            {
+                return explicitPath;
+            }
+
+            var navisTemp = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            return Path.Combine(navisTemp, "DaabNavisExport");
+        }
+
+        private static void ExportViewpointsToXml(Document document, ExportContext context)
+        {
+            context.ViewSequence.Clear();
+
+            var settings = new XmlWriterSettings
+            {
+                Encoding = new UTF8Encoding(false),
+                Indent = true,
+                IndentChars = "  ",
+                NewLineOnAttributes = false
+            };
+
+            Directory.CreateDirectory(Path.GetDirectoryName(context.XmlPath)!);
+
+            using var writer = XmlWriter.Create(context.XmlPath, settings);
+            writer.WriteStartDocument();
+            writer.WriteStartElement("exchange");
+            writer.WriteAttributeString("units", document.Units.ToString());
+            var sourcePath = document.FileName ?? string.Empty;
+            var fileName = string.IsNullOrEmpty(sourcePath) ? string.Empty : Path.GetFileName(sourcePath) ?? string.Empty;
+            writer.WriteAttributeString("filename", fileName);
+            writer.WriteAttributeString("filepath", sourcePath);
+
+            writer.WriteStartElement("viewpoints");
+            foreach (SavedItem item in document.SavedViewpoints.RootItems)
+            {
+                WriteSavedItem(writer, item, context);
+            }
+            writer.WriteEndElement(); // viewpoints
+
+            writer.WriteEndElement(); // exchange
+            writer.WriteEndDocument();
+        }
+
+        private static void WriteSavedItem(XmlWriter writer, SavedItem item, ExportContext context)
+        {
+            switch (item)
+            {
+                case GroupItem folder:
+                    WriteFolder(writer, folder, context);
+                    break;
+                case SavedViewpoint viewpoint:
+                    WriteView(writer, viewpoint, context);
+                    break;
+            }
+        }
+
+        private static void WriteFolder(XmlWriter writer, GroupItem folder, ExportContext context)
+        {
+            writer.WriteStartElement("viewfolder");
+            writer.WriteAttributeString("name", folder.DisplayName ?? string.Empty);
+            writer.WriteAttributeString("guid", folder.Guid.ToString());
+
+            foreach (SavedItem child in folder.Children)
+            {
+                WriteSavedItem(writer, child, context);
+            }
+
+            writer.WriteEndElement();
+        }
+
+        private static void WriteView(XmlWriter writer, SavedViewpoint viewpoint, ExportContext context)
+        {
+            context.ViewSequence.Add(viewpoint);
+
+            writer.WriteStartElement("view");
+            writer.WriteAttributeString("name", viewpoint.DisplayName ?? string.Empty);
+            writer.WriteAttributeString("guid", viewpoint.Guid.ToString());
+
+            var comments = viewpoint.Comments;
+            if (comments != null && comments.Count > 0)
+            {
+                writer.WriteStartElement("comments");
+                foreach (Comment comment in comments)
+                {
+                    writer.WriteStartElement("comment");
+                    writer.WriteAttributeString("id", comment.Guid.ToString());
+                    writer.WriteAttributeString("status", comment.Status.ToString());
+                    writer.WriteElementString("user", comment.Author ?? string.Empty);
+                    writer.WriteElementString("body", comment.Body ?? string.Empty);
+                    WriteCreatedDate(writer, comment.CreationDate);
+                    writer.WriteEndElement();
+                }
+
+                writer.WriteEndElement();
+            }
+
+            writer.WriteEndElement();
+        }
+
+        private static void WriteCreatedDate(XmlWriter writer, DateTime created)
+        {
+            if (created.Year < 1900)
+            {
+                return;
+            }
+
+            writer.WriteStartElement("createddate");
+            writer.WriteStartElement("date");
+            writer.WriteAttributeString("year", created.Year.ToString(CultureInfo.InvariantCulture));
+            writer.WriteAttributeString("month", created.Month.ToString(CultureInfo.InvariantCulture));
+            writer.WriteAttributeString("day", created.Day.ToString(CultureInfo.InvariantCulture));
+            writer.WriteEndElement();
+            writer.WriteEndElement();
+        }
+
+        private static void ExportViewpointImages(ExportContext context, IEnumerable<IReadOnlyList<string?>> rows)
+        {
+            if (context.ViewSequence.Count == 0)
+            {
+                return;
+            }
+
+            Directory.CreateDirectory(context.ImagesDirectory);
+
+            var imageAssignments = new Dictionary<Guid, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var row in rows)
+            {
+                if (row.Count <= 10)
+                {
+                    continue;
+                }
+
+                var guidText = row[4];
+                var imagePath = row[10];
+                if (string.IsNullOrWhiteSpace(guidText) || string.IsNullOrWhiteSpace(imagePath))
+                {
+                    continue;
+                }
+
+                if (!Guid.TryParse(guidText, out var guid))
+                {
+                    continue;
+                }
+
+                if (!imageAssignments.ContainsKey(guid))
+                {
+                    imageAssignments.Add(guid, imagePath);
+                }
+            }
+
+            foreach (var viewpoint in context.ViewSequence)
+            {
+                if (!imageAssignments.TryGetValue(viewpoint.Guid, out var imageFile))
+                {
+                    continue;
+                }
+
+                var targetPath = Path.Combine(context.ImagesDirectory, imageFile);
+                using var bitmap = viewpoint.GenerateThumbnail(new Size(800, 450));
+                if (bitmap == null)
+                {
+                    continue;
+                }
+
+                bitmap.Save(targetPath, System.Drawing.Imaging.ImageFormat.Jpeg);
+            }
+        }
+    }
+}

--- a/DaabNavisExport/Parsing/NavisworksXmlParser.cs
+++ b/DaabNavisExport/Parsing/NavisworksXmlParser.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace DaabNavisExport.Parsing
+{
+    internal sealed class NavisworksXmlParser
+    {
+        public const string CsvFileName = "navisworks_views_comments.csv";
+        public const string DebugFileName = "debug.txt";
+
+        public ParseResult Process(string xmlPath, bool streamDebug = false)
+        {
+            if (!File.Exists(xmlPath))
+            {
+                throw new FileNotFoundException("XML file not found", xmlPath);
+            }
+
+            var rows = new List<List<string?>>();
+            var debug = new List<string>();
+            var seen = new HashSet<(string? Guid, string? CommentId)>();
+            var viewCounter = 0;
+
+            void Log(string message)
+            {
+                debug.Add(message);
+                if (streamDebug)
+                {
+                    System.Diagnostics.Debug.WriteLine(message);
+                }
+            }
+
+            var document = XDocument.Load(xmlPath);
+            var root = document.Root ?? throw new InvalidDataException("Invalid XML: missing root");
+            var viewFolders = root.Element("viewpoints")?.Elements("viewfolder") ?? Enumerable.Empty<XElement>();
+
+            foreach (var folder in viewFolders)
+            {
+                RecurseFolder(folder, new List<string>(), rows, seen, ref viewCounter, Log);
+            }
+
+            return new ParseResult(rows, debug);
+        }
+
+        public void WriteOutputs(ParseResult result, string outputDirectory)
+        {
+            Directory.CreateDirectory(outputDirectory);
+
+            var csvPath = Path.Combine(outputDirectory, CsvFileName);
+            using (var writer = new StreamWriter(csvPath, false, new UTF8Encoding(false)))
+            {
+                WriteCsvLine(writer, new[]
+                {
+                    "Category",
+                    "Level",
+                    "Subfolder",
+                    "ViewName",
+                    "GUID",
+                    "CommentID",
+                    "Status",
+                    "User",
+                    "Body",
+                    "CreatedDate",
+                    "ImagePath"
+                });
+
+                foreach (var row in result.Rows)
+                {
+                    WriteCsvLine(writer, row.Select(field => field ?? string.Empty));
+                }
+            }
+
+            File.WriteAllLines(Path.Combine(outputDirectory, DebugFileName), result.DebugLines, new UTF8Encoding(false));
+        }
+
+        private static void WriteCsvLine(TextWriter writer, IEnumerable<string> fields)
+        {
+            var builder = new StringBuilder();
+            var first = true;
+            foreach (var field in fields)
+            {
+                if (!first)
+                {
+                    builder.Append(',');
+                }
+                else
+                {
+                    first = false;
+                }
+
+                builder.Append('"');
+                builder.Append(field.Replace("\"", "\"\""));
+                builder.Append('"');
+            }
+
+            writer.WriteLine(builder.ToString());
+        }
+
+        private static void RecurseFolder(
+            XElement folder,
+            List<string> path,
+            ICollection<List<string?>> rows,
+            ISet<(string? Guid, string? CommentId)> seen,
+            ref int viewCounter,
+            Action<string> log)
+        {
+            var folderName = folder.Attribute("name")?.Value ?? string.Empty;
+            var newPath = new List<string>(path) { folderName };
+
+            log($"📂 Entering folder: {string.Join(" > ", newPath.Where(p => !string.IsNullOrWhiteSpace(p)))}");
+
+            foreach (var view in folder.Elements("view"))
+            {
+                viewCounter++;
+                var viewName = view.Attribute("name")?.Value ?? string.Empty;
+                var guid = view.Attribute("guid")?.Value ?? string.Empty;
+                var imageFile = $"vp{viewCounter.ToString("0000", CultureInfo.InvariantCulture)}.jpg";
+
+                log($"  👀 Found view: {viewName} (GUID={guid}) → {imageFile}");
+
+                var commentsNode = view.Element("comments");
+                if (commentsNode != null)
+                {
+                    foreach (var comment in commentsNode.Elements("comment"))
+                    {
+                        var row = BuildRow(newPath, viewName, guid, comment, imageFile, log);
+                        AddRow(row, rows, seen, log);
+                    }
+                }
+                else
+                {
+                    var row = BuildEmptyCommentRow(newPath, viewName, guid, imageFile);
+                    AddRow(row, rows, seen, log);
+                }
+            }
+
+            foreach (var child in folder.Elements("viewfolder"))
+            {
+                RecurseFolder(child, newPath, rows, seen, ref viewCounter, log);
+            }
+        }
+
+        private static List<string?> BuildRow(
+            IReadOnlyList<string> path,
+            string viewName,
+            string guid,
+            XElement comment,
+            string imageFile,
+            Action<string> log)
+        {
+            var commentId = comment.Attribute("id")?.Value;
+            var status = comment.Attribute("status")?.Value;
+            var user = comment.Element("user")?.Value;
+            var body = comment.Element("body")?.Value;
+            var created = ParseCreatedDate(comment.Element("createddate"), log);
+
+            log($"    💬 Comment ID={commentId}, Status={status}, User={user}");
+
+            return new List<string?>
+            {
+                path.ElementAtOrDefault(0),
+                path.ElementAtOrDefault(1),
+                path.Count > 2 ? string.Join(" > ", path.Skip(2)) : null,
+                viewName,
+                guid,
+                commentId,
+                status,
+                user,
+                body,
+                created,
+                imageFile
+            };
+        }
+
+        private static List<string?> BuildEmptyCommentRow(
+            IReadOnlyList<string> path,
+            string viewName,
+            string guid,
+            string imageFile)
+        {
+            return new List<string?>
+            {
+                path.ElementAtOrDefault(0),
+                path.ElementAtOrDefault(1),
+                path.Count > 2 ? string.Join(" > ", path.Skip(2)) : null,
+                viewName,
+                guid,
+                null,
+                null,
+                null,
+                null,
+                null,
+                imageFile
+            };
+        }
+
+        private static string? ParseCreatedDate(XElement? createdNode, Action<string> log)
+        {
+            try
+            {
+                var dateNode = createdNode?.Element("date");
+                if (dateNode == null)
+                {
+                    return null;
+                }
+
+                var year = SafeParse(dateNode.Attribute("year")?.Value);
+                var month = SafeParse(dateNode.Attribute("month")?.Value);
+                var day = SafeParse(dateNode.Attribute("day")?.Value);
+
+                if (year < 1900 || month <= 0 || day <= 0)
+                {
+                    return null;
+                }
+
+                var dt = new DateTime(year, month, day);
+                return dt.ToString("yyyy/MM/dd", CultureInfo.InvariantCulture);
+            }
+            catch (Exception ex)
+            {
+                log($"❌ Failed to parse createddate: {ex.Message}");
+                return null;
+            }
+        }
+
+        private static int SafeParse(string? value)
+        {
+            return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) ? parsed : 0;
+        }
+
+        private static void AddRow(
+            List<string?> row,
+            ICollection<List<string?>> rows,
+            ISet<(string? Guid, string? CommentId)> seen,
+            Action<string> log)
+        {
+            var key = (row.ElementAtOrDefault(4), row.ElementAtOrDefault(5));
+            if (seen.Contains(key))
+            {
+                log($"⚠️ Duplicate skipped: GUID={key.Item1}, CommentID={key.Item2}");
+                return;
+            }
+
+            seen.Add(key);
+            rows.Add(row);
+        }
+    }
+}

--- a/DaabNavisExport/Parsing/ParseResult.cs
+++ b/DaabNavisExport/Parsing/ParseResult.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace DaabNavisExport.Parsing
+{
+    internal sealed class ParseResult
+    {
+        public ParseResult(IReadOnlyList<List<string?>> rows, IReadOnlyList<string> debugLines)
+        {
+            var projected = new List<IReadOnlyList<string?>>(rows.Count);
+            foreach (var row in rows)
+            {
+                projected.Add(row);
+            }
+
+            Rows = projected;
+            DebugLines = debugLines;
+        }
+
+        public IReadOnlyList<IReadOnlyList<string?>> Rows { get; }
+
+        public IReadOnlyList<string> DebugLines { get; }
+    }
+}

--- a/DaabNavisExport/Properties/AssemblyInfo.cs
+++ b/DaabNavisExport/Properties/AssemblyInfo.cs
@@ -1,0 +1,12 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("DaabNavisExport")]
+[assembly: AssemblyDescription("Navisworks 2026 export automation for Daab Reports")]
+[assembly: AssemblyCompany("Daab Reports")]
+[assembly: AssemblyProduct("DaabNavisExport")]
+[assembly: AssemblyCopyright("Copyright © Daab Reports")]
+[assembly: ComVisible(false)]
+[assembly: Guid("e324e173-2803-489b-b727-34a96e616d67")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/DaabNavisExport/README.md
+++ b/DaabNavisExport/README.md
@@ -1,0 +1,72 @@
+# Daab Navis Export
+
+This folder contains a Navisworks 2026 add-in that automates the Daab Reports export workflow. The add-in performs the following actions when executed inside Autodesk Navisworks Manage or Simulate 2026:
+
+1. Exports all saved viewpoints (and their folder hierarchy) from the active document to a Navisworks exchange XML file.
+2. Runs the logic from `parseXml.py` (ported to C# in `Parsing/NavisworksXmlParser.cs`) to transform the XML into the `navisworks_views_comments.csv` structure used by the Power BI template.
+3. Writes a `debug.txt` log that mirrors the diagnostics produced by the Python tooling.
+4. Exports viewport images (JPEG) whose filenames align with the `ImagePath` column produced by the parser.
+
+The resulting files are written beneath `%USERPROFILE%\Documents\DaabNavisExport\<Project Name>` by default. You can supply a different output directory by passing a path parameter in the Navisworks **Add-Ins** window when you launch the plugin.
+
+## Project layout
+
+```
+DaabNavisExport/
+├── DaabNavisExport.csproj          # .NET Framework 4.8 class library project
+├── ExportPlugin.cs                 # Add-in entry point (`ExportPlugin`)
+├── Parsing/
+│   ├── NavisworksXmlParser.cs      # C# port of parseXml.py
+│   └── ParseResult.cs              # Parser result container
+├── Properties/
+│   └── AssemblyInfo.cs             # Assembly metadata
+├── Utilities/
+│   ├── ExportContext.cs            # Export session state
+│   └── PathSanitizer.cs            # File/Path helper utilities
+└── parseXml.py                     # Original Python script for reference
+```
+
+## Building
+
+1. Open the solution folder in Visual Studio 2022.
+2. Add references to the Navisworks 2026 API assemblies:
+   - `Autodesk.Navisworks.Api.dll`
+   - `Autodesk.Navisworks.Api.DocumentParts.dll`
+   These are typically located in `C:\Program Files\Autodesk\Navisworks Manage 2026\api\`. Ensure the references are set to **Copy Local = false**.
+3. Build the project in **Release** mode. The output `DaabNavisExport.dll` will be placed in `bin/Release`.
+
+## Deployment
+
+1. Create an add-in bundle folder (e.g. `%APPDATA%\Autodesk\Navisworks Manage 2026\Plugins\DaabNavisExport.bundle`).
+2. Inside the bundle, add the compiled `DaabNavisExport.dll`, the `parseXml.py` reference file (optional), and a `PackageContents.xml` similar to the following:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<ApplicationPackage SchemaVersion="1.0" AutodeskProduct="Navisworks" ProductType="Application" Name="Daab Navis Export" Description="Exports viewpoints, comments, and images to Daab Reports format." AppVersion="1.0" ProductCode="{E324E173-2803-489B-B727-34A96E616D67}" UpgradeCode="{31D68667-ED13-4805-B5D7-3E06D814AF03}">
+  <CompanyDetails Name="Daab Reports" Url="https://daabreports.example"/>
+  <Components>
+    <RuntimeRequirements SeriesMin="2026" SeriesMax="2026"/>
+    <ComponentEntry AppName="DaabNavisExport" Version="1.0" ModuleName="DaabNavisExport.dll" AppType="Application" LoadOnStartUp="True"/>
+  </Components>
+</ApplicationPackage>
+```
+
+3. Launch Navisworks 2026 and open the **Add-Ins** tab. You should find **Daab Navis Export** listed. Running it will produce the following structure (matching the sample project layout):
+
+   ```
+   <Project Name>/
+   ├── DB/
+   │   ├── DB.xml
+   │   ├── debug.txt
+   │   └── navisworks_views_comments.csv
+   └── Images/
+       ├── vp0001.jpg
+       ├── vp0002.jpg
+       └── ...
+   ```
+
+## Notes
+
+- The parser honours the same duplicate filtering, logging format, and date parsing rules as the original Python implementation in `1717 N FLAG/DB/ParseXml.py`.
+- Image thumbnails are generated at 800×450 resolution; adjust `GenerateThumbnail` parameters in `ExportPlugin.cs` if a different size is required.
+- If the add-in is executed without any saved viewpoints, the XML and CSV will still be generated but remain empty aside from headers.

--- a/DaabNavisExport/Utilities/ExportContext.cs
+++ b/DaabNavisExport/Utilities/ExportContext.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using Autodesk.Navisworks.Api;
+
+namespace DaabNavisExport.Utilities
+{
+    internal sealed class ExportContext
+    {
+        public ExportContext(
+            Document document,
+            string rootDirectory,
+            string projectDirectory,
+            string dbDirectory,
+            string imagesDirectory,
+            string xmlPath)
+        {
+            Document = document;
+            RootDirectory = rootDirectory;
+            ProjectDirectory = projectDirectory;
+            DbDirectory = dbDirectory;
+            ImagesDirectory = imagesDirectory;
+            XmlPath = xmlPath;
+            ViewSequence = new List<SavedViewpoint>();
+        }
+
+        public Document Document { get; }
+
+        public string RootDirectory { get; }
+
+        public string ProjectDirectory { get; }
+
+        public string DbDirectory { get; }
+
+        public string ImagesDirectory { get; }
+
+        public string XmlPath { get; }
+
+        public List<SavedViewpoint> ViewSequence { get; }
+    }
+}

--- a/DaabNavisExport/Utilities/PathSanitizer.cs
+++ b/DaabNavisExport/Utilities/PathSanitizer.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace DaabNavisExport.Utilities
+{
+    internal static class PathSanitizer
+    {
+        private static readonly char[] InvalidFileNameChars = Path.GetInvalidFileNameChars();
+
+        public static string ToSafeFileName(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return "navisworks";
+            }
+
+            var builder = new StringBuilder(value.Length);
+            foreach (var ch in value)
+            {
+                builder.Append(InvalidFileNameChars.Contains(ch) ? '_' : ch);
+            }
+
+            var sanitized = builder.ToString().Trim();
+            return string.IsNullOrEmpty(sanitized) ? "navisworks" : sanitized;
+        }
+
+        public static string ToSafePath(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return "";
+            }
+
+            var invalid = Path.GetInvalidPathChars();
+            var sanitized = new string(value.Select(ch => invalid.Contains(ch) ? '_' : ch).ToArray());
+            return sanitized;
+        }
+    }
+}

--- a/DaabNavisExport/parseXml.py
+++ b/DaabNavisExport/parseXml.py
@@ -1,0 +1,206 @@
+import argparse
+import csv
+import sys
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+
+def parse_createddate(created, log):
+    """Convert <createddate><date .../> into yyyy/mm/dd"""
+    try:
+        date_node = created.find("date") if created is not None else None
+        if date_node is None:
+            return None
+
+        year = int(date_node.attrib.get("year", 0))
+        month = int(date_node.attrib.get("month", 0))
+        day = int(date_node.attrib.get("day", 0))
+
+        if year < 1900 or month == 0 or day == 0:
+            return None
+
+        dt = datetime(year, month, day)
+        return dt.strftime("%Y/%m/%d")
+
+    except Exception as e:
+        log(
+            f"❌ Failed to parse createddate: {e}, raw={ET.tostring(created, encoding='unicode') if created is not None else 'None'}"
+        )
+        return None
+
+def add_row(row, rows, seen, log):
+    key = (row[4], row[5])  # GUID + CommentID
+    if key not in seen:
+        rows.append(row)
+        seen.add(key)
+    else:
+        log(f"⚠️ Duplicate skipped: GUID={row[4]}, CommentID={row[5]}")
+
+
+def recurse(folder, path, rows, seen, view_counter, log):
+    folder_name = folder.attrib.get("name", "")
+    new_path = path + [folder_name]
+
+    log(f"📂 Entering folder: {' > '.join(new_path)}")
+
+    for view in folder.findall("view"):
+        view_counter[0] += 1
+        view_name = view.attrib.get("name", "")
+        guid = view.attrib.get("guid", "")
+        image_file = f"vp{str(view_counter[0]).zfill(4)}.jpg"
+
+        log(f"  👀 Found view: {view_name} (GUID={guid}) → {image_file}")
+
+        comments = view.find("comments")
+        if comments is not None:
+            for comment in comments.findall("comment"):
+                cid = comment.attrib.get("id", "")
+                status = comment.attrib.get("status", "")
+                user = comment.findtext("user")
+                body = comment.findtext("body")
+                created = comment.find("createddate")
+                created_str = parse_createddate(created, log) if created is not None else None
+
+                log(f"    💬 Comment ID={cid}, Status={status}, User={user}")
+
+                add_row([
+                    new_path[0] if len(new_path) > 0 else None,
+                    new_path[1] if len(new_path) > 1 else None,
+                    " > ".join(new_path[2:]) if len(new_path) > 2 else None,
+                    view_name,
+                    guid,
+                    cid,
+                    status,
+                    user,
+                    body,
+                    created_str,
+                    image_file
+                ], rows, seen, log)
+        else:
+            log(f"    ⚠️ No comments found for {view_name}")
+            add_row([
+                new_path[0] if len(new_path) > 0 else None,
+                new_path[1] if len(new_path) > 1 else None,
+                " > ".join(new_path[2:]) if len(new_path) > 2 else None,
+                view_name,
+                guid,
+                None, None, None, None, None,
+                image_file
+            ], rows, seen, log)
+
+    for child in folder.findall("viewfolder"):
+        recurse(child, new_path, rows, seen, view_counter, log)
+
+
+def choose_file_with_dialog() -> Optional[Path]:
+    try:
+        import tkinter as tk
+        from tkinter import filedialog
+
+        root = tk.Tk()
+        root.withdraw()
+        root.update()
+        selected = filedialog.askopenfilename(
+            title="Select XML file to parse",
+            filetypes=[("XML files", "*.xml"), ("All files", "*.*")],
+        )
+        root.destroy()
+        if selected:
+            return Path(selected)
+        return None
+    except Exception:
+        return None
+
+
+def ensure_xml_path(cli_path: Optional[str]) -> Path:
+    if cli_path:
+        path = Path(cli_path)
+        if path.is_file():
+            return path
+        raise FileNotFoundError(f"XML file not found: {cli_path}")
+
+    selected = choose_file_with_dialog()
+    if selected:
+        if selected.is_file():
+            return selected
+        raise FileNotFoundError(f"Selected file not found: {selected}")
+
+    print("Please enter the path to the XML file:")
+    user_input = input().strip().strip('"')
+    if not user_input:
+        raise ValueError("No XML file selected.")
+    path = Path(user_input)
+    if path.is_file():
+        return path
+    raise FileNotFoundError(f"XML file not found: {path}")
+
+
+def process_xml(xml_path: Path, stream_debug: bool = False) -> Tuple[List[List[Optional[str]]], List[str]]:
+    rows: List[List[Optional[str]]] = []
+    debug_lines: List[str] = []
+    seen: set = set()
+    view_counter = [0]
+
+    def log(message: str) -> None:
+        debug_lines.append(message)
+        if stream_debug:
+            print(message)
+
+    tree = ET.parse(str(xml_path))
+    root = tree.getroot()
+
+    for vf in root.findall("./viewpoints/viewfolder"):
+        recurse(vf, [], rows, seen, view_counter, log)
+
+    return rows, debug_lines
+
+
+def write_outputs(rows: Sequence[Sequence[Optional[str]]], debug_lines: Sequence[str]) -> None:
+    with open("navisworks_views_comments.csv", "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            "Category",
+            "Level",
+            "Subfolder",
+            "ViewName",
+            "GUID",
+            "CommentID",
+            "Status",
+            "User",
+            "Body",
+            "CreatedDate",
+            "ImagePath",
+        ])
+        writer.writerows(rows)
+
+    with open("debug.txt", "w", encoding="utf-8") as f:
+        f.write("\n".join(debug_lines))
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Parse Navisworks XML comments into CSV")
+    parser.add_argument("path", nargs="?", help="Path to the XML file to parse")
+    parser.add_argument(
+        "--stream-debug",
+        action="store_true",
+        help="Stream debug log messages to the console while processing",
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        xml_path = ensure_xml_path(args.path)
+        rows, debug_lines = process_xml(xml_path, stream_debug=args.stream_debug)
+        write_outputs(rows, debug_lines)
+    except Exception as exc:
+        print(f"❌ Error: {exc}")
+        return 1
+
+    print("✅ Processing complete. Check navisworks_views_comments.csv and debug.txt")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- ensure the export plugin builds a `<Project>/DB` and `<Project>/Images` tree that mirrors the sample 1717 N FLAG layout
- route XML, CSV, and debug outputs into the DB folder and save thumbnails inside the Images folder referenced by the CSV
- document the expected project folder structure in the add-in README

## Testing
- not run (Navisworks add-ins cannot be executed in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d4b6a6b52c832e9bf416b5d91acda0