### PR TITLE
Fix Navisworks add-in packaging and ribbon naming

### DIFF
--- a/DaabNavisExport/DaabNavisExport.csproj
+++ b/DaabNavisExport/DaabNavisExport.csproj
@@ -1,21 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFramework>net48</TargetFramework>
-		<PlatformTarget>x64</PlatformTarget>
-		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-		<Nullable>enable</Nullable>
-		<LangVersion>latest</LangVersion>
-		<RootNamespace>DaabNavisExport</RootNamespace>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-		<OutputPath>C:\ProgramData\Autodesk\ApplicationPlugins\DaabNavisExport\Contents\2026\</OutputPath>
-	</PropertyGroup>
-	<ItemGroup>
-		<Reference Include="Autodesk.Navisworks.Api">
-			<HintPath>C:\Program Files\Autodesk\Navisworks Manage 2026\Autodesk.Navisworks.Api.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="System.Drawing" />
-		<Reference Include="System.Windows.Forms" />
-	</ItemGroup>
+        <PropertyGroup>
+                <TargetFramework>net48</TargetFramework>
+                <PlatformTarget>x64</PlatformTarget>
+                <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+                <Nullable>enable</Nullable>
+                <LangVersion>latest</LangVersion>
+                <RootNamespace>DaabNavisExport</RootNamespace>
+                <OutputPath>C:\ProgramData\Autodesk\ApplicationPlugins\DaabNavisExport\Contents\2026\</OutputPath>
+        </PropertyGroup>
+        <ItemGroup>
+                <Reference Include="Autodesk.Navisworks.Api">
+                        <HintPath>C:\Program Files\Autodesk\Navisworks Manage 2026\Autodesk.Navisworks.Api.dll</HintPath>
+                        <Private>false</Private>
+                </Reference>
+                <Reference Include="System.Drawing" />
+                <Reference Include="System.Windows.Forms" />
+        </ItemGroup>
+        <ItemGroup>
+                <None Update="PackageContents.xml">
+                        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+                        <TargetPath>..\..\PackageContents.xml</TargetPath>
+                </None>
+        </ItemGroup>
 </Project>

--- a/DaabNavisExport/ExportPlugin.cs
+++ b/DaabNavisExport/ExportPlugin.cs
@@ -20,8 +20,9 @@ namespace DaabNavisExport
     [Plugin(
         "DaabNavisExport",
         "DAAB",
-        DisplayName = "Daab Navis Export",
+        DisplayName = "DaabReport",
         ToolTip = "Exports Navisworks viewpoints and comments to Daab Reports format")]
+    [AddInPlugin(AddInLocation.AddIn, OverrideDisplayName = "DaabReport")]
     public class ExportPlugin : AddInPlugin
     {
         private const string DbFolderName = "DB";

--- a/DaabNavisExport/PackageContents.xml
+++ b/DaabNavisExport/PackageContents.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ApplicationPackage SchemaVersion="1.0" AutodeskProduct="Navisworks" ProductType="Application" Name="Daab Navis Export" Description="Exports viewpoints, comments, and images to Daab Reports format." AppVersion="1.0" ProductCode="{E324E173-2803-489B-B727-34A96E616D67}" UpgradeCode="{31D68667-ED13-4805-B5D7-3E06D814AF03}">
+  <CompanyDetails Name="Daab Reports" Url="https://daabreports.com" />
+  <Components>
+    <RuntimeRequirements SeriesMin="2026" SeriesMax="2026" />
+    <ComponentEntry AppName="DaabNavisExport" ModuleName="DaabNavisExport.dll" AppType="Application" LoadOnStartUp="True" />
+  </Components>
+</ApplicationPackage>


### PR DESCRIPTION
## Summary
- update the add-in metadata so the button is shown as **DaabReport** on the Navisworks ribbon
- add a PackageContents.xml and copy rule so the bundle loads automatically from ProgramData
- set every build configuration to emit the DLL directly into `C:\ProgramData\Autodesk\ApplicationPlugins\DaabNavisExport\Contents\2026\`

## Testing
- Not run (environment lacks the Navisworks build tooling)


------
https://chatgpt.com/codex/tasks/task_e_68d5829b2d3c832ebe478487ecf88ed8