### PR TITLE
Improve viewpoint image export handling

### DIFF
--- a/DaabNavisExport/ExportPlugin.cs
+++ b/DaabNavisExport/ExportPlugin.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 using System.IO;
@@ -327,6 +328,11 @@ namespace DaabNavisExport
 
                 var targetPath = Path.Combine(context.ImagesDirectory, imageFile);
 
+                if (TryRenderViewpointImage(context.Document, viewpoint, targetPath, new Size(800, 450)))
+                {
+                    continue;
+                }
+
                 using var bitmap = TryGenerateThumbnail(viewpoint, new Size(800, 450));
                 if (bitmap == null)
                 {
@@ -335,6 +341,100 @@ namespace DaabNavisExport
 
                 bitmap.Save(targetPath, System.Drawing.Imaging.ImageFormat.Jpeg);
             }
+        }
+
+        private static bool TryRenderViewpointImage(Document document, SavedViewpoint viewpoint, string targetPath, Size size)
+        {
+            try
+            {
+                TryApplyViewpoint(document, viewpoint);
+
+                var activeViewProperty = document.GetType().GetProperty("ActiveView");
+                var activeView = activeViewProperty?.GetValue(document);
+                if (activeView == null)
+                {
+                    return false;
+                }
+
+                var viewType = activeView.GetType();
+
+                var renderMethod = viewType.GetMethod("RenderToImage", new[] { typeof(string), typeof(int), typeof(int) });
+                if (renderMethod != null)
+                {
+                    renderMethod.Invoke(activeView, new object[] { targetPath, size.Width, size.Height });
+                    return true;
+                }
+
+                var saveMethod = viewType.GetMethod("SaveToImage", new[] { typeof(string), typeof(int), typeof(int) });
+                if (saveMethod != null)
+                {
+                    saveMethod.Invoke(activeView, new object[] { targetPath, size.Width, size.Height });
+                    return true;
+                }
+
+                var generateMethod = viewType.GetMethod("GenerateImage", new[] { typeof(int), typeof(int) });
+                if (generateMethod?.Invoke(activeView, new object[] { size.Width, size.Height }) is Bitmap generated)
+                {
+                    using (generated)
+                    {
+                        generated.Save(targetPath, System.Drawing.Imaging.ImageFormat.Jpeg);
+                    }
+
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Failed to render viewpoint image for {viewpoint.DisplayName}: {ex.Message}");
+            }
+
+            return false;
+        }
+
+        private static bool TryApplyViewpoint(Document document, SavedViewpoint viewpoint)
+        {
+            try
+            {
+                var applied = false;
+                var savedViewpoints = document.SavedViewpoints;
+                if (savedViewpoints != null)
+                {
+                    var currentProp = savedViewpoints.GetType().GetProperty("CurrentSavedViewpoint");
+                    if (currentProp != null && currentProp.CanWrite)
+                    {
+                        currentProp.SetValue(savedViewpoints, viewpoint);
+                        applied = true;
+                    }
+                }
+
+                var applyMethod = viewpoint.GetType().GetMethod("ApplyToDocument", new[] { typeof(Document) });
+                if (applyMethod != null)
+                {
+                    applyMethod.Invoke(viewpoint, new object[] { document });
+                    applied = true;
+                }
+
+                var viewpointProperty = viewpoint.GetType().GetProperty("Viewpoint");
+                var navisViewpoint = viewpointProperty?.GetValue(viewpoint);
+                if (navisViewpoint != null)
+                {
+                    var documentType = document.GetType();
+                    var currentViewpointProperty = documentType.GetProperty("CurrentViewpoint");
+                    if (currentViewpointProperty != null && currentViewpointProperty.CanWrite)
+                    {
+                        currentViewpointProperty.SetValue(document, navisViewpoint);
+                        applied = true;
+                    }
+                }
+
+                return applied;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Failed to apply viewpoint {viewpoint.DisplayName}: {ex.Message}");
+            }
+
+            return false;
         }
 
         private static Bitmap? TryGenerateThumbnail(SavedViewpoint viewpoint, Size size)

--- a/DaabNavisExport/Parsing/NavisworksXmlParser.cs
+++ b/DaabNavisExport/Parsing/NavisworksXmlParser.cs
@@ -24,6 +24,7 @@ namespace DaabNavisExport.Parsing
             var debug = new List<string>();
             var seen = new HashSet<(string? Guid, string? CommentId)>();
             var viewCounter = 0;
+            var imagePrefix = Path.GetFileNameWithoutExtension(CsvFileName);
 
             void Log(string message)
             {
@@ -40,7 +41,7 @@ namespace DaabNavisExport.Parsing
 
             foreach (var folder in viewFolders)
             {
-                RecurseFolder(folder, new List<string>(), rows, seen, ref viewCounter, Log);
+                RecurseFolder(folder, new List<string>(), rows, seen, ref viewCounter, imagePrefix, Log);
             }
 
             return new ParseResult(rows, debug);
@@ -106,6 +107,7 @@ namespace DaabNavisExport.Parsing
             ICollection<List<string?>> rows,
             ISet<(string? Guid, string? CommentId)> seen,
             ref int viewCounter,
+            string imagePrefix,
             Action<string> log)
         {
             var folderName = folder.Attribute("name")?.Value ?? string.Empty;
@@ -118,7 +120,7 @@ namespace DaabNavisExport.Parsing
                 viewCounter++;
                 var viewName = view.Attribute("name")?.Value ?? string.Empty;
                 var guid = view.Attribute("guid")?.Value ?? string.Empty;
-                var imageFile = $"vp{viewCounter.ToString("0000", CultureInfo.InvariantCulture)}.jpg";
+                var imageFile = $"{imagePrefix}_{viewCounter.ToString("0000", CultureInfo.InvariantCulture)}.jpg";
 
                 log($"  👀 Found view: {viewName} (GUID={guid}) → {imageFile}");
 
@@ -140,8 +142,8 @@ namespace DaabNavisExport.Parsing
 
             foreach (var child in folder.Elements("viewfolder"))
             {
-                RecurseFolder(child, newPath, rows, seen, ref viewCounter, log);
-            }
+                RecurseFolder(child, newPath, rows, seen, ref viewCounter, imagePrefix, log);
+        }
         }
 
         private static List<string?> BuildRow(

--- a/DaabNavisExport/parseXml.py
+++ b/DaabNavisExport/parseXml.py
@@ -7,6 +7,9 @@ from pathlib import Path
 from typing import List, Optional, Sequence, Tuple
 
 
+CSV_FILE_NAME = "navisworks_views_comments.csv"
+
+
 def parse_createddate(created, log):
     """Convert <createddate><date .../> into yyyy/mm/dd"""
     try:
@@ -49,7 +52,7 @@ def recurse(folder, path, rows, seen, view_counter, log):
         view_counter[0] += 1
         view_name = view.attrib.get("name", "")
         guid = view.attrib.get("guid", "")
-        image_file = f"vp{str(view_counter[0]).zfill(4)}.jpg"
+        image_file = f"{Path(CSV_FILE_NAME).stem}_{str(view_counter[0]).zfill(4)}.jpg"
 
         log(f"  👀 Found view: {view_name} (GUID={guid}) → {image_file}")
 
@@ -158,7 +161,7 @@ def process_xml(xml_path: Path, stream_debug: bool = False) -> Tuple[List[List[O
 
 
 def write_outputs(rows: Sequence[Sequence[Optional[str]]], debug_lines: Sequence[str]) -> None:
-    with open("navisworks_views_comments.csv", "w", newline="", encoding="utf-8") as f:
+    with open(CSV_FILE_NAME, "w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
         writer.writerow([
             "Category",


### PR DESCRIPTION
## Summary
- render each saved viewpoint through the active view before falling back to thumbnails so exported images match the CSV rows
- ensure viewpoint image filenames share the navisworks_views_comments prefix used by the CSV output in both the C# parser and reference Python script

## Testing
- dotnet build DaabNavisExport/DaabNavisExport.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a61add34832ea5ab9b3c764ef0bf